### PR TITLE
Add required_files rule (CM-2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Early development. `audit`, `diff`, and `apply` work for these rules:
 - `branch_protection` (AC-3, CM-3)
 - `merge_settings` (CM-3)
 - `secret_scanning` (SI-2, SI-4)
+- `required_files` (CM-2) — audit-only; surfaces missing paths but cannot create them
 
 ## Usage
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -3,6 +3,19 @@ use serde::Deserialize;
 
 use crate::auth::user_agent;
 
+fn urlencode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char);
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
 pub struct Client {
     token: String,
 }
@@ -88,6 +101,12 @@ impl Client {
 
     pub fn get_repo(&self, org: &str, repo: &str) -> Result<Repo> {
         Ok(self.get(&format!("/repos/{org}/{repo}"))?.into_json()?)
+    }
+
+    pub fn path_exists(&self, org: &str, repo: &str, path: &str) -> Result<bool> {
+        let encoded = path.split('/').map(urlencode).collect::<Vec<_>>().join("/");
+        let endpoint = format!("/repos/{org}/{repo}/contents/{encoded}");
+        Ok(self.get_optional(&endpoint)?.is_some())
     }
 
     pub fn get_branch_protection(

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,8 @@ pub struct RepoConfig {
     pub merge: Option<MergeSettings>,
     #[serde(default)]
     pub security: Option<SecuritySettings>,
+    #[serde(default)]
+    pub required_files: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -95,8 +95,28 @@ pub fn run_all(client: &Client, org: &str, name: &str, cfg: &RepoConfig) -> Resu
     findings.push(branch_protection(client, org, name, cfg)?);
     findings.push(merge_settings(cfg, &actual_repo));
     findings.push(secret_scanning(cfg, &actual_repo));
+    findings.push(required_files(client, org, name, cfg)?);
 
     Ok(findings)
+}
+
+fn required_files(client: &Client, org: &str, repo: &str, cfg: &RepoConfig) -> Result<Finding> {
+    let mut f = Finding::new("required_files", Severity::Warning, "CM-2");
+    let want = &cfg.required_files;
+    if want.is_empty() {
+        return Ok(f.skip("no required_files configured"));
+    }
+    let mut missing = Vec::new();
+    for path in want {
+        if !client.path_exists(org, repo, path)? {
+            missing.push(path.clone());
+        }
+    }
+    if !missing.is_empty() {
+        f.fail(format!("missing: {}", missing.join(", ")));
+        f.messages.push("no automatic remediation — add files via PR".into());
+    }
+    Ok(f)
 }
 
 fn branch_protection(client: &Client, org: &str, repo: &str, cfg: &RepoConfig) -> Result<Finding> {


### PR DESCRIPTION
## Summary
- Adds `required_files` rule: warning-severity, NIST CM-2.
- Per-path existence check via `GET /repos/{org}/{repo}/contents/{path}` (404 = missing).
- Audit-only — apply emits an actionable message; no auto-create since file content can't be inferred.

## Test plan
- [ ] Add a `required_files: [\"SECURITY.md\", \"CONTRIBUTING.md\"]` block to a repo in \`.repo.yml\`.
- [ ] \`repocat audit <repo>\` reports each missing path under the \`required_files\` row.
- [ ] When all paths exist, the rule passes.
- [ ] When the block is omitted/empty, the rule skips.
- [ ] \`repocat apply\` lists no actions for this rule (read-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)