### PR TITLE
Add codeowners rule (CM-3, AC-5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Early development. `audit`, `diff`, and `apply` work for these rules:
 - `merge_settings` (CM-3)
 - `secret_scanning` (SI-2, SI-4)
 - `required_files` (CM-2) — audit-only; surfaces missing paths but cannot create them
+- `codeowners` (CM-3, AC-5) — audit-only; verifies `.github/CODEOWNERS` exists and has at least one ownership rule
 
 ## Usage
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, Result};
+use base64::{engine::general_purpose::STANDARD as B64, Engine};
 use serde::Deserialize;
 
 use crate::auth::user_agent;
@@ -109,6 +110,18 @@ impl Client {
         Ok(self.get_optional(&endpoint)?.is_some())
     }
 
+    /// Returns Some(decoded text) if the path is a file, None if 404.
+    /// Errors if the path resolves to a directory or if base64 decode fails.
+    pub fn get_file_content(&self, org: &str, repo: &str, path: &str) -> Result<Option<String>> {
+        let encoded = path.split('/').map(urlencode).collect::<Vec<_>>().join("/");
+        let endpoint = format!("/repos/{org}/{repo}/contents/{encoded}");
+        let Some(resp) = self.get_optional(&endpoint)? else { return Ok(None); };
+        let payload: ContentPayload = resp.into_json()?;
+        let bytes = B64.decode(payload.content.replace('\n', ""))
+            .map_err(|e| anyhow!("base64 decode of {path}: {e}"))?;
+        Ok(Some(String::from_utf8_lossy(&bytes).into_owned()))
+    }
+
     pub fn get_branch_protection(
         &self,
         org: &str,
@@ -119,6 +132,11 @@ impl Client {
         let Some(resp) = self.get_optional(&path)? else { return Ok(None); };
         Ok(Some(resp.into_json()?))
     }
+}
+
+#[derive(Debug, Deserialize)]
+struct ContentPayload {
+    content: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,8 @@ pub struct RepoConfig {
     pub security: Option<SecuritySettings>,
     #[serde(default)]
     pub required_files: Vec<String>,
+    #[serde(default)]
+    pub codeowners: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -96,8 +96,31 @@ pub fn run_all(client: &Client, org: &str, name: &str, cfg: &RepoConfig) -> Resu
     findings.push(merge_settings(cfg, &actual_repo));
     findings.push(secret_scanning(cfg, &actual_repo));
     findings.push(required_files(client, org, name, cfg)?);
+    findings.push(codeowners(client, org, name, cfg)?);
 
     Ok(findings)
+}
+
+fn codeowners(client: &Client, org: &str, repo: &str, cfg: &RepoConfig) -> Result<Finding> {
+    let mut f = Finding::new("codeowners", Severity::Error, "CM-3, AC-5");
+    if cfg.codeowners != Some(true) {
+        return Ok(f.skip("codeowners not required"));
+    }
+    let path = ".github/CODEOWNERS";
+    let Some(content) = client.get_file_content(org, repo, path)? else {
+        f.fail(format!("{path} is missing"));
+        f.messages.push("no automatic remediation — add file via PR".into());
+        return Ok(f);
+    };
+    let has_rule = content
+        .lines()
+        .map(str::trim)
+        .any(|l| !l.is_empty() && !l.starts_with('#'));
+    if !has_rule {
+        f.fail(format!("{path} has no ownership rules (only blank/comment lines)"));
+        f.messages.push("no automatic remediation — add owners via PR".into());
+    }
+    Ok(f)
 }
 
 fn required_files(client: &Client, org: &str, repo: &str, cfg: &RepoConfig) -> Result<Finding> {


### PR DESCRIPTION
## Summary
- Error-severity rule: requires \`.github/CODEOWNERS\` to exist and have at least one non-blank, non-comment line.
- Adds \`Client::get_file_content\` (base64-decodes the contents API payload) for content inspection.
- Opt-in via top-level \`codeowners: true\` on a repo entry; otherwise the rule skips.
- Audit-only — owners can't be inferred, so apply emits a manual-PR message.

## Test plan
- [ ] Repo with no \`.github/CODEOWNERS\` → rule fails with "missing".
- [ ] Repo with file present but only comments/blank lines → rule fails with "no ownership rules".
- [ ] Repo with at least one valid \`pattern owner\` line → rule passes.
- [ ] Without \`codeowners: true\` in config, rule skips.
- [ ] \`repocat apply\` lists no actions for this rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)