### PR TITLE
Add dependabot_security rule (SI-2, SR-3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Early development. `audit`, `diff`, and `apply` work for these rules:
 - `secret_scanning` (SI-2, SI-4)
 - `required_files` (CM-2) — audit-only; surfaces missing paths but cannot create them
 - `codeowners` (CM-3, AC-5) — audit-only; verifies `.github/CODEOWNERS` exists and has at least one ownership rule
+- `dependabot_security` (SI-2, SR-3) — vulnerability alerts, Dependabot security updates, optional `.github/dependabot.yml` presence
 
 ## Usage
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -85,6 +85,37 @@ impl Client {
         Ok(())
     }
 
+    pub fn put_no_body(&self, path: &str) -> Result<()> {
+        let url = format!("https://api.github.com{path}");
+        ureq::put(&url)
+            .set("Authorization", &format!("Bearer {}", self.token))
+            .set("Accept", "application/vnd.github+json")
+            .set("X-GitHub-Api-Version", "2022-11-28")
+            .set("User-Agent", user_agent())
+            .set("Content-Length", "0")
+            .call()
+            .map_err(|e| match e {
+                ureq::Error::Status(code, r) => {
+                    let body = r.into_string().unwrap_or_default();
+                    anyhow!("PUT {url} → {code}: {body}")
+                }
+                other => anyhow!("transport error on PUT {url}: {other}"),
+            })?;
+        Ok(())
+    }
+
+    pub fn vulnerability_alerts_enabled(&self, org: &str, repo: &str) -> Result<bool> {
+        let path = format!("/repos/{org}/{repo}/vulnerability-alerts");
+        Ok(self.get_optional(&path)?.is_some())
+    }
+
+    pub fn automated_security_fixes_enabled(&self, org: &str, repo: &str) -> Result<bool> {
+        let path = format!("/repos/{org}/{repo}/automated-security-fixes");
+        let Some(resp) = self.get_optional(&path)? else { return Ok(false); };
+        let payload: AutomatedSecurityFixes = resp.into_json()?;
+        Ok(payload.enabled && !payload.paused)
+    }
+
     pub fn put_branch_protection(
         &self,
         org: &str,
@@ -137,6 +168,13 @@ impl Client {
 #[derive(Debug, Deserialize)]
 struct ContentPayload {
     content: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct AutomatedSecurityFixes {
+    enabled: bool,
+    #[serde(default)]
+    paused: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,6 +70,8 @@ pub struct SecuritySettings {
     #[serde(default)]
     pub dependabot_security_updates: Option<bool>,
     #[serde(default)]
+    pub dependabot_config: Option<bool>,
+    #[serde(default)]
     pub dependency_review: Option<bool>,
     #[serde(default)]
     pub vulnerability_alerts: Option<bool>,

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -8,6 +8,7 @@ use std::fmt;
 pub enum Action {
     PatchRepo { summary: String, body: Value },
     PutBranchProtection { summary: String, branch: String, body: Value },
+    SimplePut { summary: String, path: String },
 }
 
 impl Action {
@@ -15,6 +16,7 @@ impl Action {
         match self {
             Action::PatchRepo { summary, .. } => summary,
             Action::PutBranchProtection { summary, .. } => summary,
+            Action::SimplePut { summary, .. } => summary,
         }
     }
 
@@ -25,6 +27,9 @@ impl Action {
             }
             Action::PutBranchProtection { branch, body, .. } => {
                 client.put_branch_protection(org, repo, branch, body)?;
+            }
+            Action::SimplePut { path, .. } => {
+                client.put_no_body(path)?;
             }
         }
         Ok(())
@@ -97,8 +102,51 @@ pub fn run_all(client: &Client, org: &str, name: &str, cfg: &RepoConfig) -> Resu
     findings.push(secret_scanning(cfg, &actual_repo));
     findings.push(required_files(client, org, name, cfg)?);
     findings.push(codeowners(client, org, name, cfg)?);
+    findings.push(dependabot_security(client, org, name, cfg)?);
 
     Ok(findings)
+}
+
+fn dependabot_security(client: &Client, org: &str, repo: &str, cfg: &RepoConfig) -> Result<Finding> {
+    let mut f = Finding::new("dependabot_security", Severity::Error, "SI-2, SR-3");
+    let Some(want) = cfg.security.as_ref() else {
+        return Ok(f.skip("no security block configured"));
+    };
+    if want.vulnerability_alerts.is_none()
+        && want.dependabot_security_updates.is_none()
+        && want.dependabot_config != Some(true)
+    {
+        return Ok(f.skip("no dependabot fields configured"));
+    }
+
+    if want.vulnerability_alerts == Some(true) {
+        if !client.vulnerability_alerts_enabled(org, repo)? {
+            f.fail("vulnerability_alerts not enabled");
+            f.actions.push(Action::SimplePut {
+                summary: "enable vulnerability alerts".into(),
+                path: format!("/repos/{org}/{repo}/vulnerability-alerts"),
+            });
+        }
+    }
+
+    if want.dependabot_security_updates == Some(true) {
+        if !client.automated_security_fixes_enabled(org, repo)? {
+            f.fail("dependabot_security_updates not enabled");
+            f.actions.push(Action::SimplePut {
+                summary: "enable Dependabot security updates".into(),
+                path: format!("/repos/{org}/{repo}/automated-security-fixes"),
+            });
+        }
+    }
+
+    if want.dependabot_config == Some(true)
+        && !client.path_exists(org, repo, ".github/dependabot.yml")?
+    {
+        f.fail(".github/dependabot.yml is missing");
+        f.messages.push("no automatic remediation — add config via PR".into());
+    }
+
+    Ok(f)
 }
 
 fn codeowners(client: &Client, org: &str, repo: &str, cfg: &RepoConfig) -> Result<Finding> {


### PR DESCRIPTION
## Summary
- New error-severity rule covering three Dependabot/SCA signals in a single check.
- Auto-remediable: vulnerability alerts (\`PUT /repos/.../vulnerability-alerts\`) and Dependabot security updates (\`PUT /repos/.../automated-security-fixes\`). Both are no-body PUTs, so introduces an \`Action::SimplePut\` variant.
- Audit-only: optional \`.github/dependabot.yml\` presence check, gated by \`security.dependabot_config: true\`.
- Action ordering: vulnerability alerts queued before automated-security-fixes, since the latter requires the former.

## Test plan
- [ ] Repo with neither toggle on, config requests both → audit reports both, apply enables both in order.
- [ ] Repo with vulnerability alerts on but security updates off → only the second action queues.
- [ ] \`security.dependabot_config: true\` and no \`.github/dependabot.yml\` → rule fails (no auto-fix).
- [ ] No \`security:\` block → rule skips.
- [ ] All three flags unset under \`security:\` → rule skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)