### PR TITLE
Add workflow_permissions rule (AC-6, SR-3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Early development. `audit`, `diff`, and `apply` work for these rules:
 - `required_files` (CM-2) — audit-only; surfaces missing paths but cannot create them
 - `codeowners` (CM-3, AC-5) — audit-only; verifies `.github/CODEOWNERS` exists and has at least one ownership rule
 - `dependabot_security` (SI-2, SR-3) — vulnerability alerts, Dependabot security updates, optional `.github/dependabot.yml` presence
+- `workflow_permissions` (AC-6, SR-3) — repo-level default `GITHUB_TOKEN` scope and PR-approval permission
 
 ## Usage
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -85,6 +85,16 @@ impl Client {
         Ok(())
     }
 
+    pub fn put_json(&self, path: &str, body: &serde_json::Value) -> Result<()> {
+        self.send_json("PUT", path, body)?;
+        Ok(())
+    }
+
+    pub fn get_workflow_permissions(&self, org: &str, repo: &str) -> Result<WorkflowPermissions> {
+        let path = format!("/repos/{org}/{repo}/actions/permissions/workflow");
+        Ok(self.get(&path)?.into_json()?)
+    }
+
     pub fn put_no_body(&self, path: &str) -> Result<()> {
         let url = format!("https://api.github.com{path}");
         ureq::put(&url)
@@ -168,6 +178,12 @@ impl Client {
 #[derive(Debug, Deserialize)]
 struct ContentPayload {
     content: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct WorkflowPermissions {
+    pub default_workflow_permissions: String,
+    pub can_approve_pull_request_reviews: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,16 @@ pub struct RepoConfig {
     pub required_files: Vec<String>,
     #[serde(default)]
     pub codeowners: Option<bool>,
+    #[serde(default)]
+    pub actions: Option<ActionsSettings>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ActionsSettings {
+    #[serde(default)]
+    pub default_workflow_permissions: Option<String>,
+    #[serde(default)]
+    pub can_approve_pull_request_reviews: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -9,6 +9,7 @@ pub enum Action {
     PatchRepo { summary: String, body: Value },
     PutBranchProtection { summary: String, branch: String, body: Value },
     SimplePut { summary: String, path: String },
+    PutJson { summary: String, path: String, body: Value },
 }
 
 impl Action {
@@ -17,6 +18,7 @@ impl Action {
             Action::PatchRepo { summary, .. } => summary,
             Action::PutBranchProtection { summary, .. } => summary,
             Action::SimplePut { summary, .. } => summary,
+            Action::PutJson { summary, .. } => summary,
         }
     }
 
@@ -30,6 +32,9 @@ impl Action {
             }
             Action::SimplePut { path, .. } => {
                 client.put_no_body(path)?;
+            }
+            Action::PutJson { path, body, .. } => {
+                client.put_json(path, body)?;
             }
         }
         Ok(())
@@ -103,8 +108,50 @@ pub fn run_all(client: &Client, org: &str, name: &str, cfg: &RepoConfig) -> Resu
     findings.push(required_files(client, org, name, cfg)?);
     findings.push(codeowners(client, org, name, cfg)?);
     findings.push(dependabot_security(client, org, name, cfg)?);
+    findings.push(workflow_permissions(client, org, name, cfg)?);
 
     Ok(findings)
+}
+
+fn workflow_permissions(client: &Client, org: &str, repo: &str, cfg: &RepoConfig) -> Result<Finding> {
+    let mut f = Finding::new("workflow_permissions", Severity::Error, "AC-6, SR-3");
+    let Some(want) = cfg.actions.as_ref() else {
+        return Ok(f.skip("no actions block configured"));
+    };
+    if want.default_workflow_permissions.is_none() && want.can_approve_pull_request_reviews.is_none() {
+        return Ok(f.skip("no actions fields configured"));
+    }
+
+    let actual = client.get_workflow_permissions(org, repo)?;
+    let mut body = serde_json::Map::new();
+
+    if let Some(want_perm) = want.default_workflow_permissions.as_deref() {
+        if want_perm != actual.default_workflow_permissions {
+            f.fail(format!(
+                "default_workflow_permissions: want {want_perm}, got {}",
+                actual.default_workflow_permissions
+            ));
+            body.insert("default_workflow_permissions".into(), json!(want_perm));
+        }
+    }
+    if let Some(want_approve) = want.can_approve_pull_request_reviews {
+        if want_approve != actual.can_approve_pull_request_reviews {
+            f.fail(format!(
+                "can_approve_pull_request_reviews: want {want_approve}, got {}",
+                actual.can_approve_pull_request_reviews
+            ));
+            body.insert("can_approve_pull_request_reviews".into(), json!(want_approve));
+        }
+    }
+
+    if !body.is_empty() {
+        f.actions.push(Action::PutJson {
+            summary: "update workflow permissions".into(),
+            path: format!("/repos/{org}/{repo}/actions/permissions/workflow"),
+            body: Value::Object(body),
+        });
+    }
+    Ok(f)
 }
 
 fn dependabot_security(client: &Client, org: &str, repo: &str, cfg: &RepoConfig) -> Result<Finding> {


### PR DESCRIPTION
## Summary
- Error-severity rule on repo-level default \`GITHUB_TOKEN\` scope (\`default_workflow_permissions: read|write\`) and \`can_approve_pull_request_reviews\`.
- Auto-remediable via PUT /repos/.../actions/permissions/workflow.
- New \`Action::PutJson\` variant — generic PUT-with-JSON-body, reusable for future rules that don't need a bespoke action.
- Companion YAML scan (unpinned actions, missing \`permissions:\` blocks) shipping in a follow-up PR.

## Config
\`\`\`yaml
actions:
  default_workflow_permissions: read
  can_approve_pull_request_reviews: false
\`\`\`

## Test plan
- [ ] Repo with \`write\` default permissions and config requests \`read\` → fail; apply flips to \`read\`.
- [ ] Already-matching settings → pass, no actions queued.
- [ ] Only one of the two fields configured → diff and remediation only touch that field.
- [ ] No \`actions:\` block → rule skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)