### PR TITLE
Add workflow_yaml rule (AC-6, SR-3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Early development. `audit`, `diff`, and `apply` work for these rules:
 - `codeowners` (CM-3, AC-5) — audit-only; verifies `.github/CODEOWNERS` exists and has at least one ownership rule
 - `dependabot_security` (SI-2, SR-3) — vulnerability alerts, Dependabot security updates, optional `.github/dependabot.yml` presence
 - `workflow_permissions` (AC-6, SR-3) — repo-level default `GITHUB_TOKEN` scope and PR-approval permission
+- `workflow_yaml` (AC-6, SR-3) — audit-only; scans `.github/workflows/*.yml` for unpinned action refs and missing `permissions:` blocks
 
 ## Usage
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -145,6 +145,14 @@ impl Client {
         Ok(self.get(&format!("/repos/{org}/{repo}"))?.into_json()?)
     }
 
+    /// Lists entries in a directory. Returns empty Vec if the path doesn't exist.
+    pub fn list_directory(&self, org: &str, repo: &str, path: &str) -> Result<Vec<DirEntry>> {
+        let encoded = path.split('/').map(urlencode).collect::<Vec<_>>().join("/");
+        let endpoint = format!("/repos/{org}/{repo}/contents/{encoded}");
+        let Some(resp) = self.get_optional(&endpoint)? else { return Ok(Vec::new()); };
+        Ok(resp.into_json()?)
+    }
+
     pub fn path_exists(&self, org: &str, repo: &str, path: &str) -> Result<bool> {
         let encoded = path.split('/').map(urlencode).collect::<Vec<_>>().join("/");
         let endpoint = format!("/repos/{org}/{repo}/contents/{encoded}");
@@ -178,6 +186,14 @@ impl Client {
 #[derive(Debug, Deserialize)]
 struct ContentPayload {
     content: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DirEntry {
+    pub name: String,
+    pub path: String,
+    #[serde(rename = "type")]
+    pub kind: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,10 @@ pub struct ActionsSettings {
     pub default_workflow_permissions: Option<String>,
     #[serde(default)]
     pub can_approve_pull_request_reviews: Option<bool>,
+    #[serde(default)]
+    pub pin_actions: Option<bool>,
+    #[serde(default)]
+    pub require_workflow_permissions: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -109,8 +109,99 @@ pub fn run_all(client: &Client, org: &str, name: &str, cfg: &RepoConfig) -> Resu
     findings.push(codeowners(client, org, name, cfg)?);
     findings.push(dependabot_security(client, org, name, cfg)?);
     findings.push(workflow_permissions(client, org, name, cfg)?);
+    findings.push(workflow_yaml(client, org, name, cfg)?);
 
     Ok(findings)
+}
+
+fn workflow_yaml(client: &Client, org: &str, repo: &str, cfg: &RepoConfig) -> Result<Finding> {
+    let mut f = Finding::new("workflow_yaml", Severity::Error, "AC-6, SR-3");
+    let Some(want) = cfg.actions.as_ref() else {
+        return Ok(f.skip("no actions block configured"));
+    };
+    let pin = want.pin_actions == Some(true);
+    let perms = want.require_workflow_permissions == Some(true);
+    if !pin && !perms {
+        return Ok(f.skip("no workflow yaml checks configured"));
+    }
+
+    let entries = client.list_directory(org, repo, ".github/workflows")?;
+    let workflow_files: Vec<_> = entries
+        .iter()
+        .filter(|e| e.kind == "file" && (e.name.ends_with(".yml") || e.name.ends_with(".yaml")))
+        .collect();
+    if workflow_files.is_empty() {
+        return Ok(f.skip("no .github/workflows/*.yml files"));
+    }
+
+    for entry in workflow_files {
+        let Some(content) = client.get_file_content(org, repo, &entry.path)? else { continue };
+        let parsed: serde_yml::Value = match serde_yml::from_str(&content) {
+            Ok(v) => v,
+            Err(e) => {
+                f.fail(format!("{}: yaml parse error: {e}", entry.name));
+                continue;
+            }
+        };
+        if pin {
+            check_action_pins(&parsed, &entry.name, &mut f);
+        }
+        if perms {
+            check_workflow_permissions_block(&parsed, &entry.name, &mut f);
+        }
+    }
+
+    if f.status == Status::Fail {
+        f.messages.push("no automatic remediation — fix workflow files via PR".into());
+    }
+    Ok(f)
+}
+
+fn check_action_pins(yml: &serde_yml::Value, file: &str, f: &mut Finding) {
+    let Some(jobs) = yml.get("jobs").and_then(|j| j.as_mapping()) else { return };
+    for (job_name, job) in jobs {
+        let job_label = job_name.as_str().unwrap_or("?");
+        if let Some(uses) = job.get("uses").and_then(|u| u.as_str()) {
+            check_one_use(uses, file, job_label, None, f);
+        }
+        let Some(steps) = job.get("steps").and_then(|s| s.as_sequence()) else { continue };
+        for (i, step) in steps.iter().enumerate() {
+            if let Some(uses) = step.get("uses").and_then(|u| u.as_str()) {
+                check_one_use(uses, file, job_label, Some(i), f);
+            }
+        }
+    }
+}
+
+fn check_one_use(uses: &str, file: &str, job: &str, step: Option<usize>, f: &mut Finding) {
+    if uses.starts_with("./") || uses.starts_with("docker://") {
+        return;
+    }
+    let Some((_, reference)) = uses.rsplit_once('@') else {
+        f.fail(format!("{file}:{job}: `{uses}` has no version reference"));
+        return;
+    };
+    let is_sha = reference.len() == 40 && reference.chars().all(|c| c.is_ascii_hexdigit());
+    if !is_sha {
+        let loc = match step {
+            Some(i) => format!("{file}:{job}[{i}]"),
+            None => format!("{file}:{job}"),
+        };
+        f.fail(format!("{loc}: unpinned `{uses}` (use SHA, not `{reference}`)"));
+    }
+}
+
+fn check_workflow_permissions_block(yml: &serde_yml::Value, file: &str, f: &mut Finding) {
+    if yml.get("permissions").is_some() {
+        return;
+    }
+    let Some(jobs) = yml.get("jobs").and_then(|j| j.as_mapping()) else { return };
+    for (job_name, job) in jobs {
+        if job.get("permissions").is_none() {
+            let label = job_name.as_str().unwrap_or("?");
+            f.fail(format!("{file}:{label}: no permissions block (top-level or job-level)"));
+        }
+    }
 }
 
 fn workflow_permissions(client: &Client, org: &str, repo: &str, cfg: &RepoConfig) -> Result<Finding> {


### PR DESCRIPTION
## Summary
- Audit-only YAML scan of \`.github/workflows/*.yml\`. Two signals:
  - **Unpinned action references** — flags any \`uses: owner/repo@<ref>\` where \`<ref>\` isn't a 40-hex SHA. Local (\`./...\`) and \`docker://\` refs are exempt.
  - **Missing permissions block** — flags workflows lacking both top-level and per-job \`permissions:\` keys.
- Walks parsed YAML (\`serde_yml::Value\`) rather than regex-matching text, so comments and multi-line strings don't false-positive.
- Both checks are independently opt-in via \`actions.pin_actions\` and \`actions.require_workflow_permissions\`.

## Config
\`\`\`yaml
actions:
  pin_actions: true
  require_workflow_permissions: true
\`\`\`

## Test plan
- [ ] Workflow with \`uses: actions/checkout@v4\` → fail (unpinned).
- [ ] Workflow with \`uses: actions/checkout@<40-hex-sha>\` → pass.
- [ ] Workflow with \`uses: ./.github/actions/local\` → pass (local exempt).
- [ ] Workflow with no top-level \`permissions:\` and a job missing \`permissions:\` → fail.
- [ ] Workflow with top-level \`permissions:\` only → pass.
- [ ] No \`.github/workflows\` dir → rule skips.
- [ ] Both flags off / no \`actions:\` block → rule skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)