### PR TITLE
Add signed_commits rule (SI-7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Early development. `audit`, `diff`, and `apply` work for these rules:
 - `dependabot_security` (SI-2, SR-3) — vulnerability alerts, Dependabot security updates, optional `.github/dependabot.yml` presence
 - `workflow_permissions` (AC-6, SR-3) — repo-level default `GITHUB_TOKEN` scope and PR-approval permission
 - `workflow_yaml` (AC-6, SR-3) — audit-only; scans `.github/workflows/*.yml` for unpinned action refs and missing `permissions:` blocks
+- `signed_commits` (SI-7) — required-signatures enforcement on the protected branch
 
 ## Usage
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -95,6 +95,32 @@ impl Client {
         Ok(self.get(&path)?.into_json()?)
     }
 
+    pub fn required_signatures_enabled(&self, org: &str, repo: &str, branch: &str) -> Result<bool> {
+        let path = format!("/repos/{org}/{repo}/branches/{branch}/protection/required_signatures");
+        let Some(resp) = self.get_optional(&path)? else { return Ok(false); };
+        let payload: RequiredSignatures = resp.into_json()?;
+        Ok(payload.enabled)
+    }
+
+    pub fn post_no_body(&self, path: &str) -> Result<()> {
+        let url = format!("https://api.github.com{path}");
+        ureq::post(&url)
+            .set("Authorization", &format!("Bearer {}", self.token))
+            .set("Accept", "application/vnd.github+json")
+            .set("X-GitHub-Api-Version", "2022-11-28")
+            .set("User-Agent", user_agent())
+            .set("Content-Length", "0")
+            .call()
+            .map_err(|e| match e {
+                ureq::Error::Status(code, r) => {
+                    let body = r.into_string().unwrap_or_default();
+                    anyhow!("POST {url} → {code}: {body}")
+                }
+                other => anyhow!("transport error on POST {url}: {other}"),
+            })?;
+        Ok(())
+    }
+
     pub fn put_no_body(&self, path: &str) -> Result<()> {
         let url = format!("https://api.github.com{path}");
         ureq::put(&url)
@@ -194,6 +220,11 @@ pub struct DirEntry {
     pub path: String,
     #[serde(rename = "type")]
     pub kind: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct RequiredSignatures {
+    enabled: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,6 +61,8 @@ pub struct BranchProtection {
     pub block_force_push: bool,
     #[serde(default)]
     pub block_deletions: bool,
+    #[serde(default)]
+    pub signed_commits: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -9,6 +9,7 @@ pub enum Action {
     PatchRepo { summary: String, body: Value },
     PutBranchProtection { summary: String, branch: String, body: Value },
     SimplePut { summary: String, path: String },
+    SimplePost { summary: String, path: String },
     PutJson { summary: String, path: String, body: Value },
 }
 
@@ -18,6 +19,7 @@ impl Action {
             Action::PatchRepo { summary, .. } => summary,
             Action::PutBranchProtection { summary, .. } => summary,
             Action::SimplePut { summary, .. } => summary,
+            Action::SimplePost { summary, .. } => summary,
             Action::PutJson { summary, .. } => summary,
         }
     }
@@ -32,6 +34,9 @@ impl Action {
             }
             Action::SimplePut { path, .. } => {
                 client.put_no_body(path)?;
+            }
+            Action::SimplePost { path, .. } => {
+                client.post_no_body(path)?;
             }
             Action::PutJson { path, body, .. } => {
                 client.put_json(path, body)?;
@@ -110,8 +115,27 @@ pub fn run_all(client: &Client, org: &str, name: &str, cfg: &RepoConfig) -> Resu
     findings.push(dependabot_security(client, org, name, cfg)?);
     findings.push(workflow_permissions(client, org, name, cfg)?);
     findings.push(workflow_yaml(client, org, name, cfg)?);
+    findings.push(signed_commits(client, org, name, cfg)?);
 
     Ok(findings)
+}
+
+fn signed_commits(client: &Client, org: &str, repo: &str, cfg: &RepoConfig) -> Result<Finding> {
+    let mut f = Finding::new("signed_commits", Severity::Warning, "SI-7");
+    let Some(want) = cfg.branch_protection.as_ref() else {
+        return Ok(f.skip("no branch_protection block configured"));
+    };
+    if want.signed_commits != Some(true) {
+        return Ok(f.skip("signed_commits not required"));
+    }
+    if !client.required_signatures_enabled(org, repo, &want.branch)? {
+        f.fail(format!("signed commits not enforced on `{}`", want.branch));
+        f.actions.push(Action::SimplePost {
+            summary: format!("require signed commits on `{}`", want.branch),
+            path: format!("/repos/{org}/{repo}/branches/{}/protection/required_signatures", want.branch),
+        });
+    }
+    Ok(f)
 }
 
 fn workflow_yaml(client: &Client, org: &str, repo: &str, cfg: &RepoConfig) -> Result<Finding> {


### PR DESCRIPTION
## Summary
- Warning-severity rule on the required-signatures requirement of the protected branch.
- Auto-remediable: \`POST /repos/.../branches/{branch}/protection/required_signatures\` (no body).
- New \`Action::SimplePost\` variant — symmetric with the existing \`SimplePut\`.
- Config gains \`branch_protection.signed_commits: true\`. Reuses the existing \`branch:\` field rather than introducing a parallel block.

## Config
\`\`\`yaml
branch_protection:
  branch: main
  signed_commits: true
\`\`\`

## Test plan
- [ ] Branch with signatures off, config requires them → fail; apply enables.
- [ ] Branch with signatures already on → pass.
- [ ] No \`branch_protection\` block, or \`signed_commits\` unset/false → rule skips.
- [ ] Branch protection itself missing → \`required_signatures_enabled\` returns false (the API 404s); fail with action queued (apply will fail until base protection exists, but that's the \`branch_protection\` rule's job to remediate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)