### PR TITLE
Add teams_only_access rule (AC-2, AC-6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Early development. `audit`, `diff`, and `apply` work for these rules:
 - `workflow_permissions` (AC-6, SR-3) — repo-level default `GITHUB_TOKEN` scope and PR-approval permission
 - `workflow_yaml` (AC-6, SR-3) — audit-only; scans `.github/workflows/*.yml` for unpinned action refs and missing `permissions:` blocks
 - `signed_commits` (SI-7) — required-signatures enforcement on the protected branch
+- `teams_only_access` (AC-2, AC-6) — audit-only; flags direct collaborators and team-permission drift
 
 ## Usage
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -172,6 +172,16 @@ impl Client {
     }
 
     /// Lists entries in a directory. Returns empty Vec if the path doesn't exist.
+    pub fn list_direct_collaborators(&self, org: &str, repo: &str) -> Result<Vec<Collaborator>> {
+        let path = format!("/repos/{org}/{repo}/collaborators?affiliation=direct&per_page=100");
+        Ok(self.get(&path)?.into_json()?)
+    }
+
+    pub fn list_repo_teams(&self, org: &str, repo: &str) -> Result<Vec<RepoTeam>> {
+        let path = format!("/repos/{org}/{repo}/teams?per_page=100");
+        Ok(self.get(&path)?.into_json()?)
+    }
+
     pub fn list_directory(&self, org: &str, repo: &str, path: &str) -> Result<Vec<DirEntry>> {
         let encoded = path.split('/').map(urlencode).collect::<Vec<_>>().join("/");
         let endpoint = format!("/repos/{org}/{repo}/contents/{encoded}");
@@ -212,6 +222,18 @@ impl Client {
 #[derive(Debug, Deserialize)]
 struct ContentPayload {
     content: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Collaborator {
+    pub login: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RepoTeam {
+    pub slug: String,
+    pub name: String,
+    pub permission: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,14 @@ pub struct RepoConfig {
     pub codeowners: Option<bool>,
     #[serde(default)]
     pub actions: Option<ActionsSettings>,
+    #[serde(default)]
+    pub teams: Vec<TeamSpec>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TeamSpec {
+    pub name: String,
+    pub permission: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -1,4 +1,4 @@
-use crate::api::{BranchProtection as ActualBp, Client, Repo as ActualRepo};
+use crate::api::{BranchProtection as ActualBp, Client, Repo as ActualRepo, RepoTeam};
 use crate::config::{BranchProtection as DesiredBp, RepoConfig};
 use anyhow::Result;
 use serde_json::{json, Value};
@@ -116,8 +116,49 @@ pub fn run_all(client: &Client, org: &str, name: &str, cfg: &RepoConfig) -> Resu
     findings.push(workflow_permissions(client, org, name, cfg)?);
     findings.push(workflow_yaml(client, org, name, cfg)?);
     findings.push(signed_commits(client, org, name, cfg)?);
+    findings.push(teams_only_access(client, org, name, cfg)?);
 
     Ok(findings)
+}
+
+fn teams_only_access(client: &Client, org: &str, repo: &str, cfg: &RepoConfig) -> Result<Finding> {
+    let mut f = Finding::new("teams_only_access", Severity::Warning, "AC-2, AC-6");
+    if cfg.teams.is_empty() {
+        return Ok(f.skip("no teams block configured"));
+    }
+
+    let direct: Vec<_> = client
+        .list_direct_collaborators(org, repo)?
+        .into_iter()
+        .map(|c| c.login)
+        .collect();
+    if !direct.is_empty() {
+        f.fail(format!(
+            "direct collaborators (should be on a team): {}",
+            direct.join(", ")
+        ));
+    }
+
+    let attached = client.list_repo_teams(org, repo)?;
+    for want in &cfg.teams {
+        match find_team(&attached, &want.name) {
+            None => f.fail(format!("team `{}` not attached to repo", want.name)),
+            Some(actual) if actual.permission != want.permission => f.fail(format!(
+                "team `{}` permission: want {}, got {}",
+                want.name, want.permission, actual.permission
+            )),
+            Some(_) => {}
+        }
+    }
+
+    if f.status == Status::Fail {
+        f.messages.push("no automatic remediation — adjust access via org settings".into());
+    }
+    Ok(f)
+}
+
+fn find_team<'a>(attached: &'a [RepoTeam], name: &str) -> Option<&'a RepoTeam> {
+    attached.iter().find(|t| t.name == name || t.slug == name)
 }
 
 fn signed_commits(client: &Client, org: &str, repo: &str, cfg: &RepoConfig) -> Result<Finding> {


### PR DESCRIPTION
## Summary
- Warning-severity rule covering two access-hygiene signals:
  - **Direct collaborators** — any user with affiliation=direct (i.e. added to the repo, not via team).
  - **Team drift** — any \`teams:\` entry that is either not attached to the repo or attached with a different permission than declared.
- Audit-only. Both auto-remediations are high-blast-radius: removing a direct collaborator can lock someone out, and attaching/detaching teams requires org-owner scope. Surfacing for manual review is the right default.
- Opt-in via a non-empty \`teams:\` block. Absence skips the rule, since not all repos have migrated to teams.

## Config
\`\`\`yaml
teams:
  - { name: eng-write, permission: push }
  - { name: eng-admin, permission: admin }
\`\`\`

Permission values match the GitHub API: \`pull\`, \`triage\`, \`push\`, \`maintain\`, \`admin\`.

## Test plan
- [ ] Repo with one direct collaborator → fail; login appears in the message.
- [ ] Repo with all access via teams → pass on the collaborator signal.
- [ ] Configured team not attached → fail.
- [ ] Configured team attached with \`pull\` but config wants \`push\` → fail with the diff.
- [ ] Empty/absent \`teams:\` block → skip.
- [ ] No \`apply\`-side actions queued in any case (audit-only).

## Known limitations
- Pagination capped at 100 collaborators / 100 teams per repo. Plotzy scale is well under this; revisit if a repo grows past it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)