### PR TITLE
Schema reconciliation: align .repo.yml to GitHub-favored names

### DIFF
--- a/.repo.yml
+++ b/.repo.yml
@@ -27,6 +27,7 @@ repos:
       required_status_checks: []
       block_force_push: true
       block_deletions: true
+      signed_commits: false  # flip to true once commit signing is set up locally
 
     merge:
       allow_squash: true
@@ -38,15 +39,14 @@ repos:
       secret_scanning: true
       push_protection: true
       dependabot_security_updates: true
-      dependency_review: true
+      dependency_review: true  # parsed but not yet enforced — see Module A open questions
       vulnerability_alerts: true
-      signed_commits_required: false  # flip to true once commit signing is set up locally
 
     required_files:
       - README.md
       - LICENSE
       - .gitignore
 
-    workflows:
-      default_token_permissions: read
+    actions:
+      default_workflow_permissions: read
       pin_actions_to_sha: true

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@ use serde::Deserialize;
 use std::{collections::BTreeMap, fs, path::Path};
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     pub org: String,
     #[serde(default)]
@@ -11,6 +12,7 @@ pub struct Config {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RepoConfig {
     #[serde(default)]
     pub visibility: Option<String>,
@@ -33,24 +35,27 @@ pub struct RepoConfig {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TeamSpec {
     pub name: String,
     pub permission: String,
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ActionsSettings {
     #[serde(default)]
     pub default_workflow_permissions: Option<String>,
     #[serde(default)]
     pub can_approve_pull_request_reviews: Option<bool>,
     #[serde(default)]
-    pub pin_actions: Option<bool>,
+    pub pin_actions_to_sha: Option<bool>,
     #[serde(default)]
     pub require_workflow_permissions: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct BranchProtection {
     pub branch: String,
     #[serde(default)]
@@ -74,6 +79,7 @@ pub struct BranchProtection {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct MergeSettings {
     #[serde(default)]
     pub allow_squash: Option<bool>,
@@ -86,6 +92,7 @@ pub struct MergeSettings {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SecuritySettings {
     #[serde(default)]
     pub secret_scanning: Option<bool>,
@@ -99,8 +106,6 @@ pub struct SecuritySettings {
     pub dependency_review: Option<bool>,
     #[serde(default)]
     pub vulnerability_alerts: Option<bool>,
-    #[serde(default)]
-    pub signed_commits_required: Option<bool>,
 }
 
 pub fn load(path: &Path) -> Result<Config> {

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -184,7 +184,7 @@ fn workflow_yaml(client: &Client, org: &str, repo: &str, cfg: &RepoConfig) -> Re
     let Some(want) = cfg.actions.as_ref() else {
         return Ok(f.skip("no actions block configured"));
     };
-    let pin = want.pin_actions == Some(true);
+    let pin = want.pin_actions_to_sha == Some(true);
     let perms = want.require_workflow_permissions == Some(true);
     if !pin && !perms {
         return Ok(f.skip("no workflow yaml checks configured"));


### PR DESCRIPTION
## Summary
The committed \`.repo.yml\` had three drifts from the Rust schema. With no \`deny_unknown_fields\`, serde silently dropped the unknown blocks/fields and the affected rules skipped — the user thought they were enforcing while \`audit\` reported "no actions block configured."

| .repo.yml (before) | Resolution | Rationale |
|---|---|---|
| \`workflows:\` block | \`actions:\` (struct already had this) | GitHub UI calls the section "Actions"; API path is \`/actions/permissions/workflow\`. |
| \`workflows.default_token_permissions\` | \`actions.default_workflow_permissions\` | Literal GitHub API field name. |
| \`security.signed_commits_required\` | \`branch_protection.signed_commits\` | GitHub UI places "Require signed commits" inside the branch protection rule. |

When spec and GitHub diverge on naming, this resolves toward GitHub so the DSL stays searchable against api.github.com docs.

## Other changes
- Rename \`pin_actions\` → \`pin_actions_to_sha\` (descriptive; no GitHub native term to match).
- Drop the now-orphan \`SecuritySettings.signed_commits_required\` field.
- Add \`#[serde(deny_unknown_fields)]\` to every config struct.
- Leave \`security.dependency_review\` parsed-but-unread pending Module A open questions (no clean GitHub API field maps to it).

## Verification
- \`cargo build\` clean (only the pre-existing 4 dead-field warnings on intentionally-deferred fields).
- \`./repocat audit\` against live GitHub parses the new \`.repo.yml\` and runs all 10 rules.
- Typo test: \`brnach: main\` under \`branch_protection\` now errors with line/column and a list of valid keys instead of silently no-op'ing.

## Test plan
- [ ] \`audit\` parses \`.repo.yml\` clean.
- [ ] \`workflow_permissions\` rule no longer skips on this repo (the \`actions:\` block is now seen).
- [ ] \`signed_commits\` rule reads \`branch_protection.signed_commits\` (currently \`false\` → skips).
- [ ] Introducing a typo into any block fails parse with a useful error.
- [ ] \`dependency_review: true\` in \`.repo.yml\` does not cause a parse error (deny_unknown_fields tolerates declared-but-unread fields).

## Module A open questions still on the table
1. \`dependency_review\` interpretation (API toggle vs. workflow scan vs. drop entirely).
2. Whether to strip the dead fields (\`tier\`, \`visibility\`, \`description\`) or keep them as forward-declared placeholders for Phase 2.

These are deliberately not addressed here — small, focused PR, and both decisions are reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)