### PR TITLE
Strip dead config fields

### DIFF
--- a/.repo.yml
+++ b/.repo.yml
@@ -10,13 +10,9 @@
 #     org-scoped baseline, not here.
 
 org: Battle-Creek-LLC
-tier: non-production
 
 repos:
   repocat:
-    visibility: public
-    description: "GitHub repository hardening CLI"
-
     branch_protection:
       branch: main
       required_reviews: 0

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,18 +6,12 @@ use std::{collections::BTreeMap, fs, path::Path};
 #[serde(deny_unknown_fields)]
 pub struct Config {
     pub org: String,
-    #[serde(default)]
-    pub tier: Option<String>,
     pub repos: BTreeMap<String, RepoConfig>,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepoConfig {
-    #[serde(default)]
-    pub visibility: Option<String>,
-    #[serde(default)]
-    pub description: Option<String>,
     #[serde(default)]
     pub branch_protection: Option<BranchProtection>,
     #[serde(default)]


### PR DESCRIPTION
Removes `tier`, `visibility`, `description` from both the structs and `.repo.yml`. They were declared but no rule consumed them — dead config implies enforcement that isn't happening, which is worse than nothing.

If Phase 2 adds rules for visibility drift, description hygiene, or tier-based rule selection, the fields come back with the rule that uses them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)