### PR TITLE
Wire dependency_review across L1 (server) + L3 (workflow)

### DIFF
--- a/.repo.yml
+++ b/.repo.yml
@@ -35,7 +35,7 @@ repos:
       secret_scanning: true
       push_protection: true
       dependabot_security_updates: true
-      dependency_review: true  # parsed but not yet enforced — see Module A open questions
+      dependency_graph: true   # L1: server-side toggle (auto-on for public repos)
       vulnerability_alerts: true
 
     required_files:
@@ -46,3 +46,4 @@ repos:
     actions:
       default_workflow_permissions: read
       pin_actions_to_sha: true
+      require_dependency_review_action: true   # L3: workflow-level dep-review enforcement

--- a/src/api.rs
+++ b/src/api.rs
@@ -267,6 +267,8 @@ pub struct Repo {
     pub full_name: String,
     pub default_branch: String,
     #[serde(default)]
+    pub private: bool,
+    #[serde(default)]
     pub allow_squash_merge: Option<bool>,
     #[serde(default)]
     pub allow_merge_commit: Option<bool>,
@@ -284,6 +286,8 @@ pub struct SecurityAndAnalysis {
     pub secret_scanning: Option<Toggle>,
     #[serde(default)]
     pub secret_scanning_push_protection: Option<Toggle>,
+    #[serde(default)]
+    pub dependency_graph: Option<Toggle>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,6 +46,8 @@ pub struct ActionsSettings {
     pub pin_actions_to_sha: Option<bool>,
     #[serde(default)]
     pub require_workflow_permissions: Option<bool>,
+    #[serde(default)]
+    pub require_dependency_review_action: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -97,7 +99,7 @@ pub struct SecuritySettings {
     #[serde(default)]
     pub dependabot_config: Option<bool>,
     #[serde(default)]
-    pub dependency_review: Option<bool>,
+    pub dependency_graph: Option<bool>,
     #[serde(default)]
     pub vulnerability_alerts: Option<bool>,
 }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -112,7 +112,7 @@ pub fn run_all(client: &Client, org: &str, name: &str, cfg: &RepoConfig) -> Resu
     findings.push(secret_scanning(cfg, &actual_repo));
     findings.push(required_files(client, org, name, cfg)?);
     findings.push(codeowners(client, org, name, cfg)?);
-    findings.push(dependabot_security(client, org, name, cfg)?);
+    findings.push(dependabot_security(client, org, name, cfg, &actual_repo)?);
     findings.push(workflow_permissions(client, org, name, cfg)?);
     findings.push(workflow_yaml(client, org, name, cfg)?);
     findings.push(signed_commits(client, org, name, cfg)?);
@@ -186,7 +186,8 @@ fn workflow_yaml(client: &Client, org: &str, repo: &str, cfg: &RepoConfig) -> Re
     };
     let pin = want.pin_actions_to_sha == Some(true);
     let perms = want.require_workflow_permissions == Some(true);
-    if !pin && !perms {
+    let dep_review = want.require_dependency_review_action == Some(true);
+    if !pin && !perms && !dep_review {
         return Ok(f.skip("no workflow yaml checks configured"));
     }
 
@@ -196,9 +197,15 @@ fn workflow_yaml(client: &Client, org: &str, repo: &str, cfg: &RepoConfig) -> Re
         .filter(|e| e.kind == "file" && (e.name.ends_with(".yml") || e.name.ends_with(".yaml")))
         .collect();
     if workflow_files.is_empty() {
+        if dep_review {
+            f.fail("require_dependency_review_action set, but no workflows present");
+            f.messages.push("no automatic remediation — add a dependency-review workflow via PR".into());
+            return Ok(f);
+        }
         return Ok(f.skip("no .github/workflows/*.yml files"));
     }
 
+    let mut has_dep_review_action = false;
     for entry in workflow_files {
         let Some(content) = client.get_file_content(org, repo, &entry.path)? else { continue };
         let parsed: serde_yml::Value = match serde_yml::from_str(&content) {
@@ -214,12 +221,36 @@ fn workflow_yaml(client: &Client, org: &str, repo: &str, cfg: &RepoConfig) -> Re
         if perms {
             check_workflow_permissions_block(&parsed, &entry.name, &mut f);
         }
+        if dep_review && !has_dep_review_action {
+            has_dep_review_action = uses_dependency_review_action(&parsed);
+        }
+    }
+
+    if dep_review && !has_dep_review_action {
+        f.fail("no workflow uses actions/dependency-review-action");
     }
 
     if f.status == Status::Fail {
         f.messages.push("no automatic remediation — fix workflow files via PR".into());
     }
     Ok(f)
+}
+
+fn uses_dependency_review_action(yml: &serde_yml::Value) -> bool {
+    let Some(jobs) = yml.get("jobs").and_then(|j| j.as_mapping()) else { return false };
+    for (_, job) in jobs {
+        let Some(steps) = job.get("steps").and_then(|s| s.as_sequence()) else { continue };
+        for step in steps {
+            let Some(uses) = step.get("uses").and_then(|u| u.as_str()) else { continue };
+            let key = uses.split('@').next().unwrap_or(uses);
+            if key == "actions/dependency-review-action"
+                || key.starts_with("actions/dependency-review-action/")
+            {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 fn check_action_pins(yml: &serde_yml::Value, file: &str, f: &mut Finding) {
@@ -310,7 +341,13 @@ fn workflow_permissions(client: &Client, org: &str, repo: &str, cfg: &RepoConfig
     Ok(f)
 }
 
-fn dependabot_security(client: &Client, org: &str, repo: &str, cfg: &RepoConfig) -> Result<Finding> {
+fn dependabot_security(
+    client: &Client,
+    org: &str,
+    repo: &str,
+    cfg: &RepoConfig,
+    actual_repo: &ActualRepo,
+) -> Result<Finding> {
     let mut f = Finding::new("dependabot_security", Severity::Error, "SI-2, SR-3");
     let Some(want) = cfg.security.as_ref() else {
         return Ok(f.skip("no security block configured"));
@@ -318,6 +355,7 @@ fn dependabot_security(client: &Client, org: &str, repo: &str, cfg: &RepoConfig)
     if want.vulnerability_alerts.is_none()
         && want.dependabot_security_updates.is_none()
         && want.dependabot_config != Some(true)
+        && want.dependency_graph != Some(true)
     {
         return Ok(f.skip("no dependabot fields configured"));
     }
@@ -338,6 +376,30 @@ fn dependabot_security(client: &Client, org: &str, repo: &str, cfg: &RepoConfig)
             f.actions.push(Action::SimplePut {
                 summary: "enable Dependabot security updates".into(),
                 path: format!("/repos/{org}/{repo}/automated-security-fixes"),
+            });
+        }
+    }
+
+    if want.dependency_graph == Some(true) {
+        let echoed = actual_repo
+            .security_and_analysis
+            .as_ref()
+            .and_then(|s| s.dependency_graph.as_ref());
+        // Public repos have the dependency graph implicitly enabled but the
+        // API omits the field from the response; treat absence as enabled.
+        let on = match echoed {
+            Some(t) => t.is_enabled(),
+            None => !actual_repo.private,
+        };
+        if !on {
+            f.fail("dependency_graph not enabled (private repo without GitHub Advanced Security?)");
+            f.actions.push(Action::PatchRepo {
+                summary: "enable dependency graph".into(),
+                body: json!({
+                    "security_and_analysis": {
+                        "dependency_graph": { "status": "enabled" }
+                    }
+                }),
             });
         }
     }


### PR DESCRIPTION
## Summary
Closes the open Module A question on \`dependency_review\`. GitHub uses the term across three layers:

| Layer | What | Where |
|---|---|---|
| L1 | Dependency graph | \`security_and_analysis.dependency_graph\` |
| L2 | Dependency review UI on PRs | Free with L1 |
| L3 | \`actions/dependency-review-action\` | Workflow YAML |

L2 is implicit. L1 and L3 each get one config field, named to match the GitHub artifact they enforce:

\`\`\`yaml
security:
  dependency_graph: true                    # L1
actions:
  require_dependency_review_action: true    # L3
\`\`\`

## L1 (server toggle, auto-remediable)
Wired into \`dependabot_security\` rule. PATCHes \`security_and_analysis.dependency_graph.status\` if drift detected.

**Public-repo gotcha**: GitHub's \`security_and_analysis\` response **omits \`dependency_graph\` entirely for public repos** (it's implicitly on). Without handling, the rule would perma-fail for every public repo. Fix: treat absent-on-public as enabled. Added \`Repo.private: bool\` for this.

## L3 (workflow scan, audit-only)
Wired into \`workflow_yaml\` rule. Walks \`.github/workflows/*.yml\`, flags if no step \`uses\` starts with \`actions/dependency-review-action\` (with strict prefix matching so \`actions/dependency-review-action-foo\` won't match).

## Side effect
Renamed \`security.dependency_review\` → \`security.dependency_graph\` to match the GitHub API field verbatim.

## Verification
- \`audit\` against \`Battle-Creek-LLC/repocat\`:
  - L1 passes (public repo, implicit graph)
  - L3 fails honestly — no dependency-review workflow exists. Expected; addressing that is a separate workflow-authoring PR.

## Test plan
- [ ] Public repo, \`dependency_graph: true\` → L1 passes without an action queued.
- [ ] Private repo without GHAS, \`dependency_graph: true\` → fails with the GHAS hint.
- [ ] No \`.github/workflows/\` at all + \`require_dependency_review_action: true\` → fails with "no workflows present."
- [ ] Workflow file containing \`uses: actions/dependency-review-action@<sha>\` → L3 passes.
- [ ] Both flags off → both checks skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)