### PR TITLE
Apply path for require_dependency_review_action

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -90,6 +90,39 @@ impl Client {
         Ok(())
     }
 
+    /// Resolves the latest release tag of an action repo to its commit SHA.
+    /// Used to SHA-pin scaffolded workflow `uses:` lines.
+    pub fn latest_action_sha(&self, owner: &str, repo: &str) -> Result<String> {
+        let release: ReleaseRef = self
+            .get(&format!("/repos/{owner}/{repo}/releases/latest"))?
+            .into_json()?;
+        let commit: CommitRef = self
+            .get(&format!("/repos/{owner}/{repo}/commits/{}", release.tag_name))?
+            .into_json()?;
+        Ok(commit.sha)
+    }
+
+    /// Creates a new file in the repo on the default branch via the contents API.
+    /// Errors if the file already exists (the contents API requires `sha` for updates,
+    /// and we deliberately don't supply one to avoid clobbering user content).
+    pub fn create_file(
+        &self,
+        org: &str,
+        repo: &str,
+        path: &str,
+        content: &str,
+        commit_message: &str,
+    ) -> Result<()> {
+        let encoded_path = path.split('/').map(urlencode).collect::<Vec<_>>().join("/");
+        let endpoint = format!("/repos/{org}/{repo}/contents/{encoded_path}");
+        let body = serde_json::json!({
+            "message": commit_message,
+            "content": B64.encode(content.as_bytes()),
+        });
+        self.send_json("PUT", &endpoint, &body)?;
+        Ok(())
+    }
+
     pub fn get_workflow_permissions(&self, org: &str, repo: &str) -> Result<WorkflowPermissions> {
         let path = format!("/repos/{org}/{repo}/actions/permissions/workflow");
         Ok(self.get(&path)?.into_json()?)
@@ -222,6 +255,16 @@ impl Client {
 #[derive(Debug, Deserialize)]
 struct ContentPayload {
     content: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReleaseRef {
+    tag_name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct CommitRef {
+    sha: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -11,6 +11,7 @@ pub enum Action {
     SimplePut { summary: String, path: String },
     SimplePost { summary: String, path: String },
     PutJson { summary: String, path: String, body: Value },
+    ScaffoldDependencyReviewWorkflow { summary: String },
 }
 
 impl Action {
@@ -21,6 +22,7 @@ impl Action {
             Action::SimplePut { summary, .. } => summary,
             Action::SimplePost { summary, .. } => summary,
             Action::PutJson { summary, .. } => summary,
+            Action::ScaffoldDependencyReviewWorkflow { summary } => summary,
         }
     }
 
@@ -41,9 +43,62 @@ impl Action {
             Action::PutJson { path, body, .. } => {
                 client.put_json(path, body)?;
             }
+            Action::ScaffoldDependencyReviewWorkflow { .. } => {
+                scaffold_dependency_review_workflow(client, org, repo)?;
+            }
         }
         Ok(())
     }
+}
+
+fn scaffold_dependency_review_workflow(client: &Client, org: &str, repo: &str) -> Result<()> {
+    let path = ".github/workflows/dependency-review.yml";
+    if client.path_exists(org, repo, path)? {
+        return Err(anyhow::anyhow!(
+            "{path} already exists; refusing to overwrite — \
+             remove or update it manually if it doesn't satisfy the rule"
+        ));
+    }
+    let checkout_sha = client.latest_action_sha("actions", "checkout")?;
+    let dep_review_sha = client.latest_action_sha("actions", "dependency-review-action")?;
+    let content = format!(
+        "name: Dependency Review\n\
+         \n\
+         on:\n\
+         \x20\x20pull_request:\n\
+         \n\
+         permissions:\n\
+         \x20\x20contents: read\n\
+         \n\
+         jobs:\n\
+         \x20\x20dependency-review:\n\
+         \x20\x20\x20\x20runs-on: ubuntu-latest\n\
+         \x20\x20\x20\x20steps:\n\
+         \x20\x20\x20\x20\x20\x20- uses: actions/checkout@{checkout_sha}\n\
+         \x20\x20\x20\x20\x20\x20- uses: actions/dependency-review-action@{dep_review_sha}\n"
+    );
+    client
+        .create_file(
+            org,
+            repo,
+            path,
+            &content,
+            "Add dependency-review workflow (scaffolded by repocat)",
+        )
+        .map_err(|e| {
+            // GitHub returns 404 (not 403) when an OAuth token lacks the `workflow`
+            // scope but tries to write under .github/workflows/. Translate so users
+            // know what to do instead of chasing a misleading 404.
+            if e.to_string().contains("404") {
+                anyhow::anyhow!(
+                    "writing to .github/workflows/ requires the `workflow` OAuth \
+                     scope, which the gh CLI does not request by default. Run \
+                     `gh auth refresh -s workflow` and retry. Underlying error: {e}"
+                )
+            } else {
+                e
+            }
+        })
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -199,7 +254,9 @@ fn workflow_yaml(client: &Client, org: &str, repo: &str, cfg: &RepoConfig) -> Re
     if workflow_files.is_empty() {
         if dep_review {
             f.fail("require_dependency_review_action set, but no workflows present");
-            f.messages.push("no automatic remediation — add a dependency-review workflow via PR".into());
+            f.actions.push(Action::ScaffoldDependencyReviewWorkflow {
+                summary: "scaffold .github/workflows/dependency-review.yml".into(),
+            });
             return Ok(f);
         }
         return Ok(f.skip("no .github/workflows/*.yml files"));
@@ -228,9 +285,12 @@ fn workflow_yaml(client: &Client, org: &str, repo: &str, cfg: &RepoConfig) -> Re
 
     if dep_review && !has_dep_review_action {
         f.fail("no workflow uses actions/dependency-review-action");
+        f.actions.push(Action::ScaffoldDependencyReviewWorkflow {
+            summary: "scaffold .github/workflows/dependency-review.yml".into(),
+        });
     }
 
-    if f.status == Status::Fail {
+    if f.status == Status::Fail && f.actions.is_empty() {
         f.messages.push("no automatic remediation — fix workflow files via PR".into());
     }
     Ok(f)


### PR DESCRIPTION
## Summary
audit/apply is the contract: audit finds drift, apply fixes it. L3 was the lone holdout among the new \`workflow_yaml\` signals. This ships the apply path.

When the rule fails because no workflow uses \`actions/dependency-review-action\`, apply scaffolds \`.github/workflows/dependency-review.yml\`:

\`\`\`yaml
name: Dependency Review

on:
  pull_request:

permissions:
  contents: read

jobs:
  dependency-review:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@<resolved at execute time>
      - uses: actions/dependency-review-action@<resolved at execute time>
\`\`\`

SHAs are fetched at execute time (not at audit time) so they're always current — and audit stays a read-only operation that doesn't burn API calls on actions repos.

## New machinery
- \`Action::ScaffoldDependencyReviewWorkflow\` variant.
- \`Client::latest_action_sha\` — release tag → commit SHA, two API hops.
- \`Client::create_file\` — PUT to the contents API, refuses to overwrite (no \`sha\` in body, so GitHub returns a clear "already exists" error).

## Token-scope footgun
GitHub returns 404 (not 403) when an OAuth token tries to write under \`.github/workflows/\` without the \`workflow\` scope. The default \`gh auth login\` flow does **not** request this scope. The error path translates the 404 to:

> writing to .github/workflows/ requires the \`workflow\` OAuth scope, which the gh CLI does not request by default. Run \`gh auth refresh -s workflow\` and retry.

Without that translation it would look like a generic "endpoint not found" — a half-hour debugging trap.

## Test plan
- [ ] Repo with no workflows + \`require_dependency_review_action: true\` → apply scaffolds the file with current SHAs.
- [ ] Repo with workflows but none using the action → same.
- [ ] Repo where \`.github/workflows/dependency-review.yml\` already exists → apply errors with "refusing to overwrite" rather than clobbering.
- [ ] Token without \`workflow\` scope → apply errors with the actionable refresh instructions.
- [ ] After scaffold, re-audit → \`workflow_yaml\` passes.

## Note for self / user
After this merges, \`apply\` against \`Battle-Creek-LLC/repocat\` will need a token refresh (\`gh auth refresh -s workflow\`) before it can write the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)