### PR TITLE
Preflight OAuth scope check for apply

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -204,6 +204,20 @@ impl Client {
         Ok(self.get(&format!("/repos/{org}/{repo}"))?.into_json()?)
     }
 
+    /// Returns the OAuth scopes attached to the current token, parsed from
+    /// the X-OAuth-Scopes response header on GET /user. Empty for fine-grained
+    /// PATs (which expose permissions differently).
+    pub fn oauth_scopes(&self) -> Result<Vec<String>> {
+        let resp = self.get("/user")?;
+        let header = resp.header("X-OAuth-Scopes").unwrap_or("");
+        Ok(header
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(String::from)
+            .collect())
+    }
+
     /// Lists entries in a directory. Returns empty Vec if the path doesn't exist.
     pub fn list_direct_collaborators(&self, org: &str, repo: &str) -> Result<Vec<Collaborator>> {
         let path = format!("/repos/{org}/{repo}/collaborators?affiliation=direct&per_page=100");

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,6 +119,10 @@ fn run(mode: Mode, raw_args: &[String]) -> Result<ExitCode> {
     eprintln!("authenticated as {login}");
     let client = api::Client::new(token);
 
+    if effective_mode == Mode::Apply {
+        preflight_scopes(&client, &cfg, &args)?;
+    }
+
     let mut any_error = false;
     let mut any_apply_error = false;
 
@@ -148,6 +152,36 @@ fn run(mode: Mode, raw_args: &[String]) -> Result<ExitCode> {
         Mode::Apply => if any_apply_error { 3 } else { 0 },
     };
     Ok(ExitCode::from(code))
+}
+
+fn preflight_scopes(client: &api::Client, cfg: &Config, args: &Args) -> Result<()> {
+    let needs_workflow = target_repos(cfg, args)?
+        .iter()
+        .any(|name| {
+            cfg.repos[*name]
+                .actions
+                .as_ref()
+                .and_then(|a| a.require_dependency_review_action)
+                .unwrap_or(false)
+        });
+    if !needs_workflow {
+        return Ok(());
+    }
+    let scopes = client.oauth_scopes()?;
+    if scopes.is_empty() {
+        // Fine-grained PAT — scopes don't appear in this header. Trust and proceed;
+        // the API will return a clear error if permissions are insufficient.
+        return Ok(());
+    }
+    if !scopes.iter().any(|s| s == "workflow") {
+        return Err(anyhow!(
+            "apply needs the `workflow` OAuth scope to scaffold dependency-review \
+             workflows, but the current token has only [{}]. Run \
+             `gh auth refresh --hostname github.com -s workflow` and retry.",
+            scopes.join(", ")
+        ));
+    }
+    Ok(())
 }
 
 fn render_table(findings: &[Finding]) {


### PR DESCRIPTION
## Summary
Mid-apply scope failures are bad UX — you've already run an audit and possibly executed other actions before hitting a 404 you can't fix. Move the check upfront.

When \`apply\` starts, if any target repo's config sets \`actions.require_dependency_review_action: true\`, verify the token has the \`workflow\` OAuth scope. Bail with the exact \`gh auth refresh\` command if not.

## Behavior
- Apply mode + scope missing → exit 2 with an actionable message before any rule runs.
- Apply mode + scope present → no change.
- Audit / diff mode → no preflight (read-only, doesn't matter).
- Fine-grained PATs (empty \`X-OAuth-Scopes\` header) → skip the check and trust the API to return clear permission errors itself. Same as today.

## Verified
\`\`\`
$ ./repocat apply --config .repo.yml
authenticated as jstockdi
error: apply needs the \`workflow\` OAuth scope to scaffold dependency-review workflows, but the current token has only [delete_repo, gist, read:org, repo]. Run \`gh auth refresh --hostname github.com -s workflow\` and retry.

$ ./repocat audit --config .repo.yml   # unaffected
...
$ ./repocat diff --config .repo.yml    # unaffected, shows the planned scaffold
\`\`\`

## Future
This generalizes: any future action that needs a non-default scope should add itself to the preflight. The current check is hardcoded to \`require_dependency_review_action\` → \`workflow\` because that's the only such action today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)