### PR TITLE
Require signed commits on main

### DIFF
--- a/.repo.yml
+++ b/.repo.yml
@@ -23,7 +23,7 @@ repos:
       required_status_checks: []
       block_force_push: true
       block_deletions: true
-      signed_commits: false  # flip to true once commit signing is set up locally
+      signed_commits: true
 
     merge:
       allow_squash: true


### PR DESCRIPTION
## Summary

Flips `branch_protection.signed_commits: false → true`. After this lands and `repocat apply` runs, GitHub will enforce `required_signatures` on `main` — every direct push must be signed and verified.

Local SSH commit signing is configured and the GitHub-side signing key is registered (this PR's commit was just verified by GitHub as proof).

## Operational impact

- Squash-merges from PRs continue to work — GitHub web-flow merge commits are signed by GitHub's own key.
- Direct `git push origin main` from any machine without a configured signing key (and a matching key registered on the GitHub account) will be rejected.
- This is reversible: flip back to `false` and `apply` to disable.

## Test plan

- [x] Local commit is signed (`gpgsig` header present in commit object)
- [x] GitHub verification: `verified: true, reason: valid`
- [ ] After merge, run `repocat audit` — `signed_commits` rule should fail (yml says true, GitHub still says false until apply)
- [ ] Run `repocat apply` to enable required_signatures on main
- [ ] Re-audit — should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)