### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities privately via GitHub's
+[private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
+feature on this repository's **Security** tab.
+
+We aim to acknowledge reports within 5 business days and provide an
+initial assessment within 10 business days. Please do not file public
+issues for security-sensitive reports.
+
+## Supported Versions
+
+This project follows a rolling-release model — only the current `main`
+branch is supported.


### PR DESCRIPTION
Documents the private vulnerability reporting flow. Closes the last drift item from the strict-solo baseline.