### PR TITLE
Add release workflow for prebuilt binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing tag to attach binaries to (e.g. v0.1.0)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  upload-assets:
+    name: ${{ matrix.target }}
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Install Linux build dependencies
+        if: startsWith(matrix.os, 'ubuntu-')
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+
+      - name: Build and upload archive
+        uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6 # v1.30.2
+        with:
+          bin: repocat
+          target: ${{ matrix.target }}
+          tar: unix
+          zip: windows
+          locked: true
+          checksum: sha256
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || '' }}

--- a/README.md
+++ b/README.md
@@ -3,6 +3,25 @@
 GitHub repository hardening CLI. Reads a declarative `.repo.yml` baseline and
 either reports drift (`audit`) or reconciles it (`apply`).
 
+## Install
+
+Prebuilt binaries for Linux, macOS, and Windows are attached to each release.
+Pick the archive matching your platform (`x86_64-unknown-linux-gnu`,
+`aarch64-unknown-linux-gnu`, `x86_64-apple-darwin`, `aarch64-apple-darwin`, or
+`x86_64-pc-windows-msvc`):
+
+```sh
+gh release download --pattern '*<your-platform>*' -R Battle-Creek-LLC/repocat
+tar -xzf repocat-*.tar.gz
+mv repocat /usr/local/bin/
+```
+
+Or build from source:
+
+```sh
+cargo install --git https://github.com/Battle-Creek-LLC/repocat
+```
+
 ## Status
 
 Early development. `audit`, `diff`, and `apply` work for these rules:


### PR DESCRIPTION
Closes #20.

## Summary
- New `.github/workflows/release.yml` builds and uploads archives to GitHub Releases on every `v*` tag push (and on `workflow_dispatch` for ad-hoc reruns against an existing tag).
- Five targets: `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `x86_64-apple-darwin`, `aarch64-apple-darwin`, `x86_64-pc-windows-msvc`.
- ARM Linux relies on `taiki-e/upload-rust-binary-action`'s built-in `cross` integration (no extra setup needed).
- Linux runners install `libdbus-1-dev` + `pkg-config` for the `keyring` crate, mirroring `ci.yml`.
- `permissions: contents: write` is scoped to the `upload-assets` job; workflow-level perms remain `contents: read`.
- Third-party actions pinned to commit SHAs:
  - `actions/checkout` -> `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (matches CI workflow)
  - `taiki-e/upload-rust-binary-action` -> `f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6` (v1.30.2)
- README gets a short Install section above Status with prebuilt-binary and `cargo install --git` paths.

## Test plan
- [x] Run `workflow_dispatch` against an existing tag once merged to confirm all five matrix legs build and upload.
- [x] Tag a future `v*` release and confirm archives appear with a single top-level `repocat`/`repocat.exe` plus sha256 checksums.