### PR TITLE
Per-platform install docs and CHANGELOG for v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] — 2026-04-29
+
+First tagged release. The CLI is functional end-to-end against GitHub.com,
+covering ten built-in rules with NIST 800-53 control mappings.
+
+### Added
+
+- `audit`, `diff`, and `apply` commands covering ten rules: `branch_protection`,
+  `merge_settings`, `secret_scanning`, `required_files`, `codeowners`,
+  `dependabot_security`, `workflow_permissions`, `workflow_yaml`,
+  `signed_commits`, and `teams_only_access`.
+- `init` command with three opinionated presets (`minimal`, `standard`,
+  `strict`). Templates are heavily commented and double as the live schema
+  reference via `repocat init --preset strict --stdout`.
+- `repo add <name>` for appending a repo entry to an existing baseline while
+  preserving comments.
+- Top-level `defaults:` block. Per-repo entries overlay defaults: scalars
+  override, vec fields extend and dedupe, nested struct fields recurse with the
+  same rules.
+- `--format json` and `--format sarif` output for `audit`, suitable for
+  downstream tooling and GitHub Code Scanning upload.
+- Preflight OAuth scope check on `apply` so runs that need the `workflow` scope
+  fail fast with an explicit `gh auth refresh` hint.
+- Prebuilt binaries on each tagged release for Linux (x86_64, aarch64), macOS
+  (x86_64, aarch64), and Windows (x86_64).
+
+[0.1.0]: https://github.com/Battle-Creek-LLC/repocat/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -5,22 +5,62 @@ either reports drift (`audit`) or reconciles it (`apply`).
 
 ## Install
 
-Prebuilt binaries for Linux, macOS, and Windows are attached to each release.
-Pick the archive matching your platform (`x86_64-unknown-linux-gnu`,
-`aarch64-unknown-linux-gnu`, `x86_64-apple-darwin`, `aarch64-apple-darwin`, or
-`x86_64-pc-windows-msvc`):
+Prebuilt binaries are attached to each [release](https://github.com/Battle-Creek-LLC/repocat/releases).
+Each archive ships a single `repocat` (or `repocat.exe`) binary plus a
+matching `.sha256` checksum.
+
+### macOS (Apple Silicon)
 
 ```sh
-gh release download --pattern '*<your-platform>*' -R Battle-Creek-LLC/repocat
-tar -xzf repocat-*.tar.gz
-mv repocat /usr/local/bin/
+gh release download --pattern 'repocat-aarch64-apple-darwin.tar.gz' -R Battle-Creek-LLC/repocat
+tar -xzf repocat-aarch64-apple-darwin.tar.gz
+sudo mv repocat /usr/local/bin/
 ```
 
-Or build from source:
+### macOS (Intel)
+
+```sh
+gh release download --pattern 'repocat-x86_64-apple-darwin.tar.gz' -R Battle-Creek-LLC/repocat
+tar -xzf repocat-x86_64-apple-darwin.tar.gz
+sudo mv repocat /usr/local/bin/
+```
+
+> Binaries aren't notarized. On first run macOS may block them — clear the
+> quarantine attribute with `xattr -d com.apple.quarantine /usr/local/bin/repocat`.
+
+### Linux (x86_64)
+
+```sh
+gh release download --pattern 'repocat-x86_64-unknown-linux-gnu.tar.gz' -R Battle-Creek-LLC/repocat
+tar -xzf repocat-x86_64-unknown-linux-gnu.tar.gz
+sudo mv repocat /usr/local/bin/
+```
+
+### Linux (ARM64)
+
+```sh
+gh release download --pattern 'repocat-aarch64-unknown-linux-gnu.tar.gz' -R Battle-Creek-LLC/repocat
+tar -xzf repocat-aarch64-unknown-linux-gnu.tar.gz
+sudo mv repocat /usr/local/bin/
+```
+
+### Windows (PowerShell)
+
+```powershell
+gh release download --pattern 'repocat-x86_64-pc-windows-msvc.zip' -R Battle-Creek-LLC/repocat
+Expand-Archive repocat-x86_64-pc-windows-msvc.zip -DestinationPath .
+# Move repocat.exe into a directory on your PATH, e.g.:
+Move-Item repocat.exe "$env:USERPROFILE\bin\"
+```
+
+### From source
 
 ```sh
 cargo install --git https://github.com/Battle-Creek-LLC/repocat
 ```
+
+On Linux the `keyring` crate needs `libdbus-1-dev` and `pkg-config` installed
+(`sudo apt-get install libdbus-1-dev pkg-config` on Debian/Ubuntu).
 
 ## Status
 


### PR DESCRIPTION
## Summary
- Replace the generic `gh release download --pattern '*<your-platform>*'` block in the README with explicit copy-paste install commands for macOS (Apple Silicon, Intel), Linux (x86_64, aarch64), and Windows (PowerShell).
- Add Gatekeeper note for unsigned macOS binaries and Linux build-deps note for `cargo install`.
- Add `CHANGELOG.md` in keep-a-changelog format documenting the v0.1.0 feature surface.

## Test plan
- [x] README renders on GitHub
- [x] CHANGELOG version link points at the v0.1.0 tag (created post-merge)