### PR TITLE
Replace serde_yml with maintained serde_yaml_ng fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,16 +306,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
-
-[[package]]
 name = "linux-keyutils"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,7 +397,7 @@ dependencies = [
  "keyring",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_yaml_ng",
  "ureq",
 ]
 
@@ -546,18 +536,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yml"
-version = "0.0.12"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",
- "libyml",
- "memchr",
  "ryu",
  "serde",
- "version_check",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -629,6 +617,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,12 +663,6 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 base64 = "0.22"
 anyhow = "1"
-serde_yml = "0.0.12"
+serde_yaml_ng = "0.10"

--- a/src/config.rs
+++ b/src/config.rs
@@ -126,7 +126,7 @@ impl RepoConfig {
 pub fn load(path: &Path) -> Result<Config> {
     let text = fs::read_to_string(path)
         .with_context(|| format!("reading {}", path.display()))?;
-    let cfg: Config = serde_yml::from_str(&text)
+    let cfg: Config = serde_yaml_ng::from_str(&text)
         .with_context(|| format!("parsing {}", path.display()))?;
     if cfg.org.trim().is_empty() {
         return Err(anyhow!("`org:` is required at the top of {}", path.display()));

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -54,7 +54,7 @@ mod tests {
             let yaml = p.template().replace("{{ORG}}", "ExampleOrg");
             // repos is empty in templates, so we test parsing directly without
             // going through config::load (which requires non-empty repos).
-            let cfg: crate::config::Config = serde_yml::from_str(&yaml)
+            let cfg: crate::config::Config = serde_yaml_ng::from_str(&yaml)
                 .unwrap_or_else(|e| panic!("{p:?} failed to parse: {e}"));
             assert_eq!(cfg.org, "ExampleOrg");
             assert!(!cfg.defaults.is_empty(), "{p:?} defaults are empty");

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -292,7 +292,7 @@ fn workflow_yaml(
     let mut has_dep_review_action = false;
     for entry in workflow_files {
         let Some(content) = client.get_file_content(org, repo, &entry.path)? else { continue };
-        let parsed: serde_yml::Value = match serde_yml::from_str(&content) {
+        let parsed: serde_yaml_ng::Value = match serde_yaml_ng::from_str(&content) {
             Ok(v) => v,
             Err(e) => {
                 f.fail(format!("{}: yaml parse error: {e}", entry.name));
@@ -340,7 +340,7 @@ fn dependency_graph_enabled(actual: &ActualRepo) -> bool {
     }
 }
 
-fn uses_dependency_review_action(yml: &serde_yml::Value) -> bool {
+fn uses_dependency_review_action(yml: &serde_yaml_ng::Value) -> bool {
     let Some(jobs) = yml.get("jobs").and_then(|j| j.as_mapping()) else { return false };
     for (_, job) in jobs {
         let Some(steps) = job.get("steps").and_then(|s| s.as_sequence()) else { continue };
@@ -357,7 +357,7 @@ fn uses_dependency_review_action(yml: &serde_yml::Value) -> bool {
     false
 }
 
-fn check_action_pins(yml: &serde_yml::Value, file: &str, f: &mut Finding) {
+fn check_action_pins(yml: &serde_yaml_ng::Value, file: &str, f: &mut Finding) {
     let Some(jobs) = yml.get("jobs").and_then(|j| j.as_mapping()) else { return };
     for (job_name, job) in jobs {
         let job_label = job_name.as_str().unwrap_or("?");
@@ -391,7 +391,7 @@ fn check_one_use(uses: &str, file: &str, job: &str, step: Option<usize>, f: &mut
     }
 }
 
-fn check_workflow_permissions_block(yml: &serde_yml::Value, file: &str, f: &mut Finding) {
+fn check_workflow_permissions_block(yml: &serde_yaml_ng::Value, file: &str, f: &mut Finding) {
     if yml.get("permissions").is_some() {
         return;
     }


### PR DESCRIPTION
## Summary

- Swap `serde_yml = "0.0.12"` for `serde_yaml_ng = "0.10"`, the maintained community fork of the original `serde_yaml` (drop-in compatible API).
- Resolves both Dependabot alerts (`GHSA-gfxp-f68g-8x78` high, `GHSA-hhw4-xg65-fp2x` medium) which trace back to the unmaintained `serde_yml`/`libyml` crates.
- Pure dependency swap: no functional or API changes. Six call sites renamed across `src/config.rs`, `src/presets.rs`, `src/rules.rs`.

Closes #24

## Test plan

- [x] `cargo build --locked` succeeds
- [x] `cargo test` passes (43/43)
- [x] `grep -E '^name = "(serde_yml|libyml)"' Cargo.lock` returns nothing
- [x] `presets::tests::templates_parse_after_substitution` exercises real-shape YAML through the new dep