### PR TITLE
Release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] — 2026-04-29
+
+### Security
+
+- Replace the unmaintained `serde_yml` crate (and its `libyml` dependency)
+  with the community-maintained [`serde_yaml_ng`](https://crates.io/crates/serde_yaml_ng)
+  fork. Closes two open Dependabot advisories: [GHSA-gfxp-f68g-8x78][]
+  (high — `libyml::string::yaml_string_extend` is unsound) and
+  [GHSA-hhw4-xg65-fp2x][] (medium — `serde_yml` crate is unmaintained).
+  YAML parsing behavior is unchanged; this is a drop-in API swap.
+
+[GHSA-gfxp-f68g-8x78]: https://github.com/advisories/GHSA-gfxp-f68g-8x78
+[GHSA-hhw4-xg65-fp2x]: https://github.com/advisories/GHSA-hhw4-xg65-fp2x
+
 ## [0.1.0] — 2026-04-29
 
 First tagged release. The CLI is functional end-to-end against GitHub.com,
@@ -31,4 +45,5 @@ covering ten built-in rules with NIST 800-53 control mappings.
 - Prebuilt binaries on each tagged release for Linux (x86_64, aarch64), macOS
   (x86_64, aarch64), and Windows (x86_64).
 
+[0.1.1]: https://github.com/Battle-Creek-LLC/repocat/releases/tag/v0.1.1
 [0.1.0]: https://github.com/Battle-Creek-LLC/repocat/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "repocat"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repocat"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## Summary
Bugfix release. Bumps `version = "0.1.1"` and adds the changelog entry.

The single fix shipped since v0.1.0 is the `serde_yml` → `serde_yaml_ng` swap (#25), which clears two open Dependabot advisories:
- High — [GHSA-gfxp-f68g-8x78](https://github.com/advisories/GHSA-gfxp-f68g-8x78)
- Medium — [GHSA-hhw4-xg65-fp2x](https://github.com/advisories/GHSA-hhw4-xg65-fp2x)

## Test plan
- [x] `cargo build --locked` clean after the version bump
- [x] `cargo test` 38/38 (no behavioral changes)
- [ ] Tag `v0.1.1` after merge — release workflow auto-cuts binaries