### PR TITLE
Release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `init --preset strict` no longer ships a `required_files` list that
   contradicts the `codeowners` rule. The strict template previously listed
-  `CODEOWNERS` under `required_files` (a literal repo-root path check) while
-  also enabling the `codeowners` rule (which reads `.github/CODEOWNERS`).
+  bare `CODEOWNERS` under `required_files` (a literal repo-root path check)
+  while also enabling the `codeowners` rule (which reads `.github/CODEOWNERS`).
   Repos following GitHub's recommended `.github/CODEOWNERS` convention would
-  permanently fail `required_files` while passing `codeowners`. Dropped the
-  redundant entry; the dedicated rule already verifies presence and content.
+  permanently fail `required_files` while passing `codeowners`. Corrected
+  the entry to `.github/CODEOWNERS` so both rules check the same path.
   ([#27](https://github.com/Battle-Creek-LLC/repocat/issues/27))
 
 ## [0.1.1] — 2026-04-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] — 2026-04-29
+
+### Fixed
+
+- `init --preset strict` no longer ships a `required_files` list that
+  contradicts the `codeowners` rule. The strict template previously listed
+  `CODEOWNERS` under `required_files` (a literal repo-root path check) while
+  also enabling the `codeowners` rule (which reads `.github/CODEOWNERS`).
+  Repos following GitHub's recommended `.github/CODEOWNERS` convention would
+  permanently fail `required_files` while passing `codeowners`. Dropped the
+  redundant entry; the dedicated rule already verifies presence and content.
+  ([#27](https://github.com/Battle-Creek-LLC/repocat/issues/27))
+
 ## [0.1.1] — 2026-04-29
 
 ### Security
@@ -45,5 +58,6 @@ covering ten built-in rules with NIST 800-53 control mappings.
 - Prebuilt binaries on each tagged release for Linux (x86_64, aarch64), macOS
   (x86_64, aarch64), and Windows (x86_64).
 
+[0.1.2]: https://github.com/Battle-Creek-LLC/repocat/releases/tag/v0.1.2
 [0.1.1]: https://github.com/Battle-Creek-LLC/repocat/releases/tag/v0.1.1
 [0.1.0]: https://github.com/Battle-Creek-LLC/repocat/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "repocat"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repocat"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [dependencies]

--- a/src/templates/strict.yml
+++ b/src/templates/strict.yml
@@ -48,12 +48,15 @@ defaults:
     require_dependency_review_action: true    # PRs blocked on vulnerable new deps
 
   # Files repocat will check exist on the default branch (CM-2 baseline config).
+  # CODEOWNERS is intentionally absent here — the dedicated `codeowners` rule
+  # below resolves it from `.github/CODEOWNERS`, which is GitHub's recommended
+  # location. Listing it here would force it to the repo root and contradict
+  # that rule for any repo following the convention.
   required_files:
     - README.md
     - LICENSE
     - .gitignore
     - SECURITY.md
-    - CODEOWNERS
 
   # Require a CODEOWNERS file with at least one ownership rule (CM-3, AC-5).
   codeowners: true

--- a/src/templates/strict.yml
+++ b/src/templates/strict.yml
@@ -48,15 +48,15 @@ defaults:
     require_dependency_review_action: true    # PRs blocked on vulnerable new deps
 
   # Files repocat will check exist on the default branch (CM-2 baseline config).
-  # CODEOWNERS is intentionally absent here — the dedicated `codeowners` rule
-  # below resolves it from `.github/CODEOWNERS`, which is GitHub's recommended
-  # location. Listing it here would force it to the repo root and contradict
-  # that rule for any repo following the convention.
+  # CODEOWNERS is listed at `.github/CODEOWNERS` to match GitHub's recommended
+  # location and the path the dedicated `codeowners` rule reads — keeping the
+  # two rules consistent for repos following the convention.
   required_files:
     - README.md
     - LICENSE
     - .gitignore
     - SECURITY.md
+    - .github/CODEOWNERS
 
   # Require a CODEOWNERS file with at least one ownership rule (CM-3, AC-5).
   codeowners: true


### PR DESCRIPTION
## Summary

Bugfix release. Fixes #27: the `strict` preset's `required_files` list contradicted its own `codeowners` rule for any repo following GitHub's recommended `.github/CODEOWNERS` convention.

- `required_files` checks literal paths.
- The `codeowners` rule reads `.github/CODEOWNERS`.
- Strict listed bare `CODEOWNERS`, so repos with `.github/CODEOWNERS` would permanently fail `required_files` while passing `codeowners`.

Corrected the entry in `src/templates/strict.yml` to `.github/CODEOWNERS` so both rules anchor to the same GitHub-recognized path. Strict baseline still explicitly requires the file.

## Test plan
- [x] `cargo build` clean after the version bump
- [x] `cargo test` 43/43 (no behavioral changes — template-only fix)
- [ ] Tag `v0.1.2` after merge — release workflow auto-cuts binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)