### PR TITLE
strict preset: enforce dependabot_config baseline

### DIFF
--- a/src/templates/strict.yml
+++ b/src/templates/strict.yml
@@ -39,6 +39,7 @@ defaults:
     push_protection: true
     vulnerability_alerts: true
     dependabot_security_updates: true
+    dependabot_config: true
     dependency_graph: true
 
   # GitHub Actions defaults (AC-6 least privilege, SR-3 supply chain).


### PR DESCRIPTION
## Summary
- Adds `dependabot_config: true` to `defaults.security` in `src/templates/strict.yml` so strict-preset repos are required to have a `.github/dependabot.yml`.
- The `dependabot_security` rule in `src/rules.rs` already implements the file-presence check; this PR just opts the strict template in.

Closes #29.

## Follow-ups deferred (raised in the issue)
- Deeper content check (verify at least one `package-ecosystem` entry, ideally one per detected language) — left for a follow-up; this PR keeps to the existing rule's semantics.
- Whether to also enable `dependabot_config: true` on the `standard` preset — not changed here; standard is intentionally lower-friction.
- Auto-generating a starter `dependabot.yml` per repo for orgs adopting the new baseline — out of scope for this PR.

## Test plan
- [x] `cargo build`
- [x] `cargo test` (43 passed)
- [ ] Run `repocat init --preset strict --stdout` and confirm `dependabot_config: true` appears under `defaults.security`
- [ ] Run `repocat diff` against a strict-baseline repo missing `.github/dependabot.yml` and confirm `dependabot_security` fails with `.github/dependabot.yml is missing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)